### PR TITLE
feat: upgrade the ethereum-etl

### DIFF
--- a/cli/polygonetl/executors/batch_work_executor.py
+++ b/cli/polygonetl/executors/batch_work_executor.py
@@ -25,7 +25,7 @@ import time
 from json.decoder import JSONDecodeError
 
 from requests.exceptions import Timeout as RequestsTimeout, HTTPError, TooManyRedirects, ConnectionError as RequestsConnectionError
-from web3.utils.threads import Timeout as Web3Timeout
+from web3._utils.threads import Timeout as Web3Timeout
 
 from polygonetl.executors.bounded_executor import BoundedExecutor
 from polygonetl.executors.fail_safe_executor import FailSafeExecutor

--- a/cli/polygonetl/providers/ipc.py
+++ b/cli/polygonetl/providers/ipc.py
@@ -25,7 +25,7 @@ import json
 import socket
 
 from web3.providers.ipc import IPCProvider
-from web3.utils.threads import (
+from web3._utils.threads import (
     Timeout,
 )
 

--- a/cli/polygonetl/providers/request.py
+++ b/cli/polygonetl/providers/request.py
@@ -4,7 +4,7 @@ import lru
 import requests
 from requests.adapters import HTTPAdapter
 
-from web3.utils.caching import (
+from web3._utils.caching import (
     generate_cache_key,
 )
 

--- a/cli/polygonetl/service/eth_service.py
+++ b/cli/polygonetl/service/eth_service.py
@@ -28,7 +28,7 @@ from web3.middleware import geth_poa_middleware
 
 class EthService(object):
     def __init__(self, web3):
-        web3.middleware_stack.inject(geth_poa_middleware, layer=0)
+        web3.middleware_onion.inject(geth_poa_middleware, layer=0)
         graph = BlockTimestampGraph(web3)
         self._graph_operations = GraphOperations(graph)
 

--- a/cli/polygonetl/streaming/eth_streamer_adapter.py
+++ b/cli/polygonetl/streaming/eth_streamer_adapter.py
@@ -34,7 +34,7 @@ class EthStreamerAdapter:
         self.item_id_calculator = EthItemIdCalculator()
         self.item_timestamp_calculator = EthItemTimestampCalculator()
         self.web3 = Web3(self.batch_web3_provider)
-        self.web3.middleware_stack.inject(geth_poa_middleware, layer=0)
+        self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     def open(self):
         self.item_exporter.open()

--- a/cli/polygonetl/web3_utils.py
+++ b/cli/polygonetl/web3_utils.py
@@ -26,5 +26,5 @@ from web3.middleware import geth_poa_middleware
 
 def build_web3(provider):
     w3 = Web3(provider)
-    w3.middleware_stack.inject(geth_poa_middleware, layer=0)
+    w3.middleware_onion.inject(geth_poa_middleware, layer=0)
     return w3

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -11,7 +11,7 @@ long_description = read("README.md") if os.path.isfile("README.md") else ""
 
 setup(
     name="polygon-etl",
-    version="0.3.5",
+    version="0.4.0",
     author="Evgeny Medvedev",
     author_email="evge.medvedev@gmail.com",
     description="Tools for exporting Polygon blockchain data to CSV or JSON",
@@ -34,15 +34,8 @@ setup(
     # collections.Mapping unsupported in 3.10 (https://bugs.python.org/issue44737)
     python_requires=">=3.7,<3.10",
     install_requires=[
-        "base58==2.1.1",
         "blockchain-etl-common==1.6.1",
-        "ethereum-etl==1.11.2",
-        "click==8.0.4",
-        "eth-abi==1.3.0",
-        "eth-utils==1.10.0",
-        "ethereum-dasm==0.1.4",
-        "requests>=2.23",
-        "web3==4.7.2",
+        "ethereum-etl==2.2.1",
         "eth-rlp==0.2.1",
         "kafka-python==2.0.2",
     ],


### PR DESCRIPTION
## Context
1. The project will be imported from [chainbase-airflow](https://github.com/chainbase-labs/chainbase-airflow), and I found the conflict bewteen the multiply ethereum-etl deps. There are the conflict scenes:
   - [ethereum-etl conflict](https://github.com/chainbase-labs/chainbase-airflow/actions/runs/5022828705/jobs/9006732856)
   - [eth-abi conflict](https://github.com/chainbase-labs/chainbase-airflow/actions/runs/5022858421/jobs/9007926314)
2. I followed the [pr](https://github.com/blockchain-etl/ethereum-etl/commit/64d16f581bcfee8b71865b22cdcf13e35f3f3ce2) to upgrade the version of the ethereum-etl

## Need to help
@zzir Please help me to check if the bump change will influence the streaming work